### PR TITLE
noweb.sty: convert file encoding to UTF-8

### DIFF
--- a/src/tex/noweb.sty
+++ b/src/tex/noweb.sty
@@ -835,13 +835,13 @@ I'll try to avoid such incompatible changes in the future.}%
   \def\@nwlangdepcud{This code is used}%
   \def\@nwlangdeprtc{Root chunk (not used in this document)}%
   \def\@nwlangdepcwf{This code is written to file}%
-  \def\@nwlangdepchk{kóða}%
-  \def\@nwlangdepchks{kóðum}%
-  \def\@nwlangdepin{í}%
+  \def\@nwlangdepchk{kÃ³Ã°a}%
+  \def\@nwlangdepchks{kÃ³Ã°um}%
+  \def\@nwlangdepin{Ã­}%
   \def\@nwlangdepand{og}%
   \def\@nwlangdepuss{Notar}%
-  \def\@nwlangdepusd{notað}%
-  \def\@nwlangdepnvu{hvergi notað}%
+  \def\@nwlangdepusd{notaÃ°}%
+  \def\@nwlangdepnvu{hvergi notaÃ°}%
   \def\@nwlangdepdfs{Skilgreinir}%
   \def\@nwlangdepnvd{hvergi skilgreint}%
 }


### PR DESCRIPTION
This fixes errors when compiling with LuaTeX that are triggered from
the Icelandic characters.