### PR TITLE
Automatic Make variables, part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,15 +45,15 @@ tar: clean source nwsrcfilter DATE emacscheck
 	chmod +w src/Makefile
 	rm -rf /tmp/noweb-$(VERSION)
 	mkdir /tmp/noweb-$(VERSION)
-	tar cvf - `find . ! -type d -not -name FAQ.old -print | ./nwsrcfilter` | (cd /tmp/noweb-$(VERSION) ; tar xf - )
-	(cd /tmp; tar cf - noweb-$(VERSION) ) | gzip -v > ../noweb-$(VERSION).tgz
+	tar cvf - `find . ! -type d -not -name FAQ.old -print | ./nwsrcfilter` | (cd /tmp/noweb-$(VERSION) && tar xf - )
+	(cd /tmp && tar cf - noweb-$(VERSION) ) | gzip -v > ../noweb-$(VERSION).tgz
 	rm -f ../noweb.tgz
-	(cd .. ; ln -s noweb-$(VERSION).tgz noweb.tgz)
+	(cd .. && ln -s noweb-$(VERSION).tgz noweb.tgz)
 	chmod -w src/Makefile
 
 ctan: clean source nwsrcfilter DATE emacscheck
 	chmod +w src/Makefile
-	(cd src; make boot)
+	(cd src && make boot)
 	rm -f ../noweb-$(VERSION)-ctan.zip
 	find ./* ! -type d -not -name FAQ.old -not -name '.git*' -print | ./nwsrcfilter | sed 's@^@noweb/@' | ( ln -s . noweb; zip ../noweb-$(VERSION)-ctan.zip -@; rm -f noweb )
 	chmod -w src/Makefile

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ tar: clean source nwsrcfilter DATE emacscheck
 
 ctan: clean source nwsrcfilter DATE emacscheck
 	chmod +w src/Makefile
-	(cd src && make boot)
+	(cd src && $(MAKE) boot)
 	rm -f ../noweb-$(VERSION)-ctan.zip
 	find ./* ! -type d -not -name FAQ.old -not -name '.git*' -print | ./nwsrcfilter | sed 's@^@noweb/@' | ( ln -s . noweb; zip ../noweb-$(VERSION)-ctan.zip -@; rm -f noweb )
 	chmod -w src/Makefile

--- a/contrib/conrado/Makefile
+++ b/contrib/conrado/Makefile
@@ -2,7 +2,7 @@ LIB=/dev/null  # to be overridden by install
 
 .SUFFIXES: .nw .icn
 .nw.icn:
-	notangle -L'#line %-1L "%F"%N' $*.nw | cpif $*.icn
+	notangle -L'#line %-1L "%F"%N' $< | cpif $@
 
 all: d2tex
 source: d2tex

--- a/contrib/jobling/Makefile
+++ b/contrib/jobling/Makefile
@@ -1,25 +1,24 @@
 PROG=correct-refs
-DOCSRC=$(PROG).tex
-PROGSRC=$(PROG).csh
 SCRIPTS=list-anchors.awk awk-scripts.awk
 
-all: correct-refs.tex correct-refs.csh all-scripts
+all: correct-refs.tex correct-refs.csh $(SCRIPTS)
 
 correct-refs.tex: correct-refs.nw
-	noweave -delay -index $< > $@
+	noweave -delay -index correct-refs.nw > $@
 
 correct-refs.csh: correct-refs.nw
-	notangle -R$@ $< | cpif $@
+	notangle -R$@ correct-refs.nw | cpif $@
 	chmod +x $@
 
-all-scripts: correct-refs.nw
-	notangle -Rlist-anchors.awk $< | cpif list-anchors.awk
-	notangle -Rawk-scripts.awk $< | cpif awk-scripts.awk
-	touch all-scripts
+list-anchors.awk: correct-refs.nw
+	notangle -R$@ correct-refs.nw | cpif $@
 
-install:
+awk-scripts.awk: correct-refs.nw
+	notangle -R$@ correct-refs.nw | cpif $@
+
+install: correct-refs.csh $(SCRIPTS)
 	cp correct-refs.csh $(HOME)/bin
-	cp *.awk $(HOME)/lib
+	cp $(SCRIPTS) $(HOME)/lib
 
 tidy:
 	-rm *~ *% *.bak *.log *.blg
@@ -28,7 +27,7 @@ clean: tidy
 	-rm *.ps *.dvi *.toc *.aux *.bbl *.dep $(PROG).shar
 
 realclean: clean
-	-rm $(DOCSRC) $(PROGSRC) $(SCRIPTS)
+	-rm correct-refs.tex correct-refs.csh $(SCRIPTS)
 
 shar:
 	shar README Makefile $(PROG).nw > $(PROG).shar

--- a/contrib/jonkrom/Makefile
+++ b/contrib/jonkrom/Makefile
@@ -1,7 +1,6 @@
 LIB=/dev/null  # override for installation
 SHELL=/bin/sh
 all: noxref.krom
-	chmod +x noxref.krom
 
 install:
 	cp noxref.krom $(LIB)
@@ -10,6 +9,7 @@ source: noxref.krom
 
 noxref.krom: noxref.nw
 	notangle -Rnoxref noxref.nw > $@
+	chmod +x $@
 
 clean:
 	/bin/rm -f *.tex *.dvi *.ilg *.idx *.aux *.log *.blg *.bbl *~ *.ind noxref.krom

--- a/contrib/kostas/Makefile
+++ b/contrib/kostas/Makefile
@@ -22,7 +22,7 @@ install:
 %.tex: %.nw
 	$(WEAVE) $< > $@
 pp.tex: pp.nw
-	noweave -delay -autodefs icon -filter icon.filter -index pp.nw > pp.tex
+	noweave -delay -autodefs icon -filter icon.filter -index pp.nw > $@
 %.dvi: %.tex
 	latex $<
 # Don't delete the intermediate .tex file.
@@ -53,9 +53,9 @@ mathdefs.icn: mathdefs.nw
 
 # Executables: autodefs.
 autodefs.oot: ootdefs.icn
-	$(ICONC) -o autodefs.oot ootdefs.icn
+	$(ICONC) -o $@ ootdefs.icn
 autodefs.math: mathdefs.icn
-	$(ICONC) -o autodefs.math mathdefs.icn
+	$(ICONC) -o $@ mathdefs.icn
 
 
 # Cleaning: remove all files that can be recreated from noweb sources.

--- a/contrib/norman/numarkup/Makefile
+++ b/contrib/norman/numarkup/Makefile
@@ -13,11 +13,11 @@ OBJS=main.o pass1.o latex.o input.o scraps.o names.o arena.o global.o
 
 all:
 	noweb -t numarkup.nw
-	make $(TARGET)
+	$(MAKE) $(TARGET)
 
 install:
 	noweb -t numarkup.nw
-	make $(TARGET)
+	$(MAKE) $(TARGET)
 	strip $(TARGET)
 	cp $(TARGET) $(LIB)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,13 +5,13 @@ NOWEAVE=noweave
 
 .SUFFIXES: .i3 .m3 .nw .tex .dvi .html
 .nw.html:
-	$(NOWEAVE) -filter l2h -filter btdefn -index -html $*.nw > $*.html
+	$(NOWEAVE) -filter l2h -filter btdefn -index -html $< > $@
 .nw.tex:
-	$(NOWEAVE) -index -filter btdefn $*.nw > $*.tex
+	$(NOWEAVE) -index -filter btdefn $< > $@
 .nw.i3:
-	$(NOTANGLE) -Rinterface -L'<* LINE %L "%F" *>%N' $*.nw > $*.i3
+	$(NOTANGLE) -Rinterface -L'<* LINE %L "%F" *>%N' $< > $@
 .nw.m3:
-	$(NOTANGLE) -L'<* LINE %L "%F" *>%N' $*.nw > $*.m3
+	$(NOTANGLE) -L'<* LINE %L "%F" *>%N' $< > $@
 .tex.dvi:
 	latex '\scrollmode \input '"$*"; while grep -s 'Rerun to get cross-references right' $*.log; do latex '\scrollmode \input '"$*"; done
 

--- a/examples/Makefile.awk
+++ b/examples/Makefile.awk
@@ -5,13 +5,13 @@ NOWEAVE=noweave
 
 .SUFFIXES: .i3 .m3 .nw .tex .dvi .html
 .nw.html:
-	$(NOWEAVE) -filter btdefn -index -html $*.nw > $*.html
+	$(NOWEAVE) -filter btdefn -index -html $< > $@
 .nw.tex:
-	$(NOWEAVE) -index -filter btdefn $*.nw > $*.tex
+	$(NOWEAVE) -index -filter btdefn $< > $@
 .nw.i3:
-	$(NOTANGLE) -Rinterface -L'<* LINE %L "%F" *>%N' $*.nw > $*.i3
+	$(NOTANGLE) -Rinterface -L'<* LINE %L "%F" *>%N' $< > $@
 .nw.m3:
-	$(NOTANGLE) -L'<* LINE %L "%F" *>%N' $*.nw > $*.m3
+	$(NOTANGLE) -L'<* LINE %L "%F" *>%N' $< > $@
 .tex.dvi:
 	latex '\scrollmode \input '"$*"; while grep -s 'Rerun to get cross-references right' $*.log; do latex '\scrollmode \input '"$*"; done
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,13 +101,13 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	cd $(LIBSRC); make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install
-	cd lib; make LIB=$(LIB) install
+	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd lib && make LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	cd $(LIBSRC); make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall
-	cd lib; make LIB=$(LIB) uninstall
+	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd lib && make LIB=$(LIB) uninstall)
 install-man:
 	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.1 > $(MANDIR)/cpif.$(MANEXT)
@@ -123,9 +123,9 @@ install-man:
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebstyle.7 > $(MAN7DIR)/nowebstyle.$(MAN7EXT)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebfilters.7 > $(MAN7DIR)/nowebfilters.$(MAN7EXT)
 	rm -f $(MANDIR)/noweave.$(MANEXT)
-	(cd $(MANDIR); ln notangle.$(MANEXT) noweave.$(MANEXT))
+	(cd $(MANDIR) && ln notangle.$(MANEXT) noweave.$(MANEXT))
 	rm -f $(MANDIR)/nountangle.$(MANEXT)
-	(cd $(MANDIR); ln notangle.$(MANEXT) nountangle.$(MANEXT))
+	(cd $(MANDIR) && ln notangle.$(MANEXT) nountangle.$(MANEXT))
 uninstall-man:
 	rm -f $(MANDIR)/cpif.$(MANEXT)
 	rm -f $(MANDIR)/nodefs.$(MANEXT)
@@ -157,9 +157,9 @@ install-gzipped-man:
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebstyle.7  | gzip -9 > $(MAN7DIR)/nowebstyle.$(MAN7EXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebfilters.7  | gzip -9 > $(MAN7DIR)/nowebfilters.$(MAN7EXT).gz
 	rm -f $(MANDIR)/noweave.$(MANEXT).gz
-	(cd $(MANDIR); ln notangle.$(MANEXT).gz noweave.$(MANEXT).gz)
+	(cd $(MANDIR) && ln notangle.$(MANEXT).gz noweave.$(MANEXT).gz)
 	rm -f $(MANDIR)/nountangle.$(MANEXT).gz
-	(cd $(MANDIR); ln notangle.$(MANEXT).gz nountangle.$(MANEXT).gz)
+	(cd $(MANDIR) && ln notangle.$(MANEXT).gz nountangle.$(MANEXT).gz)
 install-preformat-man:
 	-echo "Warning: install-preformat-man is obsolete, even on Slackware systems" 1>&2
 	mkdir -p $(MAN) $(CATDIR) $(CAT7DIR)
@@ -176,9 +176,9 @@ install-preformat-man:
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebstyle.txt  | gzip > $(CAT7DIR)/nowebstyle.$(MAN7EXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nowebfilters.txt  | gzip > $(CAT7DIR)/nowebfilters.$(MAN7EXT).gz
 	rm -f $(CATDIR)/noweave.$(MANEXT).gz
-	(cd $(CATDIR); ln notangle.$(MANEXT).gz noweave.$(MANEXT).gz)
+	(cd $(CATDIR) && ln notangle.$(MANEXT).gz noweave.$(MANEXT).gz)
 	rm -f $(CATDIR)/nountangle.$(MANEXT).gz
-	(cd $(CATDIR); ln notangle.$(MANEXT).gz nountangle.$(MANEXT).gz)
+	(cd $(CATDIR) && ln notangle.$(MANEXT).gz nountangle.$(MANEXT).gz)
 install-tex:
 	mkdir -p $(TEXINPUTS)
 	cp tex/nwmac.tex tex/noweb.sty $(TEXINPUTS)
@@ -202,7 +202,7 @@ checkin:
 source: FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) CPIF=">" $@); done
 	sleep 1
-	for i in c shell lib xdoc icon awk tex; do (cd $$i; make touch); done
+	for i in c shell lib xdoc icon awk tex; do (cd $$i && make touch); done
 touch:
 	touch FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) $@); done

--- a/src/Makefile
+++ b/src/Makefile
@@ -101,13 +101,13 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
-	(cd lib && make LIB=$(LIB) install)
+	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd lib && $(MAKE) LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
-	(cd lib && make LIB=$(LIB) uninstall)
+	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd lib && $(MAKE) LIB=$(LIB) uninstall)
 install-man:
 	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.1 > $(MANDIR)/cpif.$(MANEXT)
@@ -202,7 +202,7 @@ checkin:
 source: FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) CPIF=">" $@); done
 	sleep 1
-	for i in c shell lib xdoc icon awk tex; do (cd $$i && make touch); done
+	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) touch); done
 touch:
 	touch FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) $@); done

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -75,13 +75,13 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
-	(cd lib && make LIB=$(LIB) install)
+	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd lib && $(MAKE) LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
-	(cd lib && make LIB=$(LIB) uninstall)
+	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd lib && $(MAKE) LIB=$(LIB) uninstall)
 @ I do the [[<<shell binaries>>]] before [[$(LIBSRC)]] so that the
 Icon version of [[htmltoc]], if present, will overwrite the Perl
 version.
@@ -209,7 +209,7 @@ checkin:
 source: FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) CPIF=">" $@); done
 	sleep 1
-	for i in c shell lib xdoc icon awk tex; do (cd $$i && make touch); done
+	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) touch); done
 touch:
 	touch FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) $@); done

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -75,13 +75,13 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	cd $(LIBSRC); make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install
-	cd lib; make LIB=$(LIB) install
+	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd lib && make LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	cd $(LIBSRC); make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall
-	cd lib; make LIB=$(LIB) uninstall
+	(cd $(LIBSRC) && make ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd lib && make LIB=$(LIB) uninstall)
 @ I do the [[<<shell binaries>>]] before [[$(LIBSRC)]] so that the
 Icon version of [[htmltoc]], if present, will overwrite the Perl
 version.
@@ -147,7 +147,7 @@ done
 for i in $LINKPAGES; do
   echo '@<<ordinary pages@>>='
   echo 'rm -f $(MANDIR)/'"$i"'.$(MANEXT)'
-  echo '(cd $(MANDIR); ln notangle.$(MANEXT)' "$i"'.$(MANEXT))'
+  echo '(cd $(MANDIR) && ln notangle.$(MANEXT)' "$i"'.$(MANEXT))'
   echo '@<<uninstall ordinary pages@>>='
   echo 'rm -f $(MANDIR)/'"$i"'.$(MANEXT)'
 done
@@ -165,7 +165,7 @@ done
 
 for i in $LINKPAGES; do
   echo 'rm -f $(MANDIR)/'"$i"'.$(MANEXT).gz'
-  echo '(cd $(MANDIR); ln notangle.$(MANEXT).gz' "$i"'.$(MANEXT).gz)'
+  echo '(cd $(MANDIR) && ln notangle.$(MANEXT).gz' "$i"'.$(MANEXT).gz)'
 done
 
 echo '@<<preformatted compressed pages@>>='
@@ -181,7 +181,7 @@ done
 
 for i in $LINKPAGES; do
   echo 'rm -f $(CATDIR)/'"$i"'.$(MANEXT).gz'
-  echo '(cd $(CATDIR); ln notangle.$(MANEXT).gz' "$i"'.$(MANEXT).gz)'
+  echo '(cd $(CATDIR) && ln notangle.$(MANEXT).gz' "$i"'.$(MANEXT).gz)'
 done
 <<*>>=
 install-tex:
@@ -209,7 +209,7 @@ checkin:
 source: FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) CPIF=">" $@); done
 	sleep 1
-	for i in c shell lib xdoc icon awk tex; do (cd $$i; make touch); done
+	for i in c shell lib xdoc icon awk tex; do (cd $$i && make touch); done
 touch:
 	touch FAQ
 	for i in c shell lib xdoc icon awk tex; do (cd $$i && $(MAKE) $@); done

--- a/src/awk/Makefile
+++ b/src/awk/Makefile
@@ -12,7 +12,6 @@ BINEXECS=noindex
 EXECS=$(BINEXECS) $(LIBEXECS)
 
 all: $(EXECS)
-	chmod +x $(EXECS)
 sources: $(EXECS)
 touch: $(EXECS)
 	touch $(EXECS)
@@ -32,15 +31,19 @@ source: $(EXECS)
 
 totex: totex.nw
 	notangle -R$@ totex.nw > $@
+	chmod +x $@
 
 noidx: noidx.nw
 	notangle noidx.nw > $@
+	chmod +x $@
 
 tohtml: tohtml.nw
 	notangle tohtml.nw > $@
+	chmod +x $@
 
 noindex: noindex.nw
 	notangle -R$@ noindex.nw > $@
+	chmod +x $@
 
 clean:
 	rm -f *.log *.blg *.dvi *.toc *.aux *.tex *~ *.html

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -33,14 +33,11 @@ CPIF=>
 
 .SUFFIXES: .nw .tex .dvi .h
 .nw.tex:
-	noweave $*.nw >$*.tex
+	noweave $< > $@
 .nw.c:
-	$(NOTANGLE) -L $*.nw >$*.c
-.nw.o:
-	$(NOTANGLE) -L $*.nw >$*.c
-	$(CC) $(CFLAGS) -c $*.c
+	$(NOTANGLE) -L $< > $@
 .nw.h:
-	$(NOTANGLE) -Rheader $*.nw $(CPIF) $*.h
+	$(NOTANGLE) -Rheader $< $(CPIF) $@
 
 all: nt markup mnt finduses nwmktemp
 

--- a/src/icon/Makefile
+++ b/src/icon/Makefile
@@ -18,11 +18,11 @@ SRCS=totex.icn disambiguate.icn noidx.icn texdefs.icn icondefs.icn \
 
 .SUFFIXES: .nw .icn .html .tex .dvi
 .nw.icn:
-	notangle -L'#line %-1L "%F"%N' $*.nw $(CPIF) $*.icn
+	notangle -L'#line %-1L "%F"%N' $< $(CPIF) $@
 .nw.html:
-	noweave -filter l2h -autodefs icon -html -index $*.nw | htmltoc > $*.html
+	noweave -filter l2h -autodefs icon -html -index $< | htmltoc > $@
 .nw.tex:
-	noweave -delay -autodefs icon -index $*.nw > $*.tex
+	noweave -delay -autodefs icon -index $< > $@
 .tex.dvi:
 	latex $*; while grep -s 'Rerun to get cross' $*.log; do latex $*; done
 

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -32,6 +32,7 @@ boot:
 
 toascii: toascii.nw
 	notangle -R$@ toascii.nw > $@
+	chmod +x $@
 
 clean:
 	rm -f *.log *.blg *.dvi *.toc *.aux *.tex *~

--- a/src/xdoc/Makefile
+++ b/src/xdoc/Makefile
@@ -2,13 +2,13 @@ WWW=$(HOME)/www/noweb
 SHELL=/bin/sh
 .SUFFIXES: .1 .7 .txt .ps
 .1.txt:
-	nroff -man $*.1 > $*.txt
+	nroff -man $< > $@
 .1.ps:
-	psroff -t -man $*.1 > $*.ps
+	psroff -t -man $< > $@
 .7.txt:
-	nroff -man $*.7 > $*.txt
+	nroff -man $< > $@
 .7.ps:
-	psroff -t -man $*.7 > $*.ps
+	psroff -t -man $< > $@
 
 MANPAGES=notangle.1   cpif.1   noweb.1   nodefs.1   noroots.1   noindex.1   \
 	nowebstyle.7   nowebfilters.7   nuweb2noweb.1   sl2h.1   htmltoc.1   \


### PR DESCRIPTION
This contains a few replacements that didn't make it into #17:

- Use `$@` and `$<` in the rules (particularly suffix rules), except don't use `$<` outside of pattern/suffix rules since it isn't portable (a GNU Make extension for the first prerequisite).
- Replace `cd dir; cmd` with `(cd dir && cmd)`.
- Replace `make` with `$(MAKE)`.

Three other small changes that help when using these automatic variables:

- I've split the all-scripts target in contrib/jobling/Makefile into rules to build each of its constituent files, using `$@` as appropriate.  Removes the need to `touch all-scripts` to prevent unnecessarily rebuilding these.
- I've moved all `chmod +x` commands to where the target file is created so these can also use `$@`.
- I've removed the `.nw.o` suffix rule from src/c/Makefile, instead relying on the `.nw.c` rule followed by the usually built-in `.c.o` rule.