### PR TITLE
Improve consistency of file commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tarnames: clean source nwsrcfilter DATE
 tar: clean source nwsrcfilter DATE emacscheck
 	chmod +w src/Makefile
 	rm -rf /tmp/noweb-$(VERSION)
-	mkdir /tmp/noweb-$(VERSION)
+	mkdir -p /tmp/noweb-$(VERSION)
 	tar cvf - `find . ! -type d -not -name FAQ.old -print | ./nwsrcfilter` | (cd /tmp/noweb-$(VERSION) && tar xf - )
 	(cd /tmp && tar cf - noweb-$(VERSION) ) | gzip -v > ../noweb-$(VERSION).tgz
 	rm -f ../noweb.tgz

--- a/contrib/conrado/Makefile
+++ b/contrib/conrado/Makefile
@@ -13,4 +13,4 @@ install:
 hospital.tex: hospital.nw d2tex
 	noweave -delay -filter ./d2tex hospital.nw > $@
 clean:
-	/bin/rm -f hospital.tex *.dvi *.aux *.log *.blg *.bbl *~
+	rm -f hospital.tex *.dvi *.aux *.log *.blg *.bbl *~

--- a/contrib/davelove/Makefile
+++ b/contrib/davelove/Makefile
@@ -3,4 +3,4 @@ all:
 source:
 install:
 clean:
-	/bin/rm -f *.dvi *.log *.aux
+	rm -f *.dvi *.log *.aux

--- a/contrib/jobling/Makefile
+++ b/contrib/jobling/Makefile
@@ -21,13 +21,13 @@ install: correct-refs.csh $(SCRIPTS)
 	cp $(SCRIPTS) $(HOME)/lib
 
 tidy:
-	-rm *~ *% *.bak *.log *.blg
+	rm -f *~ *% *.bak *.log *.blg
 
 clean: tidy
-	-rm *.ps *.dvi *.toc *.aux *.bbl *.dep $(PROG).shar
+	rm -f *.ps *.dvi *.toc *.aux *.bbl *.dep $(PROG).shar
 
 realclean: clean
-	-rm correct-refs.tex correct-refs.csh $(SCRIPTS)
+	rm -f correct-refs.tex correct-refs.csh $(SCRIPTS)
 
 shar:
 	shar README Makefile $(PROG).nw > $(PROG).shar

--- a/contrib/jonkrom/Makefile
+++ b/contrib/jonkrom/Makefile
@@ -12,4 +12,4 @@ noxref.krom: noxref.nw
 	chmod +x $@
 
 clean:
-	/bin/rm -f *.tex *.dvi *.ilg *.idx *.aux *.log *.blg *.bbl *~ *.ind noxref.krom
+	rm -f *.tex *.dvi *.ilg *.idx *.aux *.log *.blg *.bbl *~ *.ind noxref.krom

--- a/contrib/kostas/Makefile
+++ b/contrib/kostas/Makefile
@@ -69,4 +69,4 @@ rem := $(rem) $(nowebs:.nw=.toc)
 
 # Also remove the Icon files for the filters.
 clean:
-	-rm -f $(rem) C.icn C++.icn icon.icn oot.icn math.icn *.filter autodefs.*
+	rm -f $(rem) C.icn C++.icn icon.icn oot.icn math.icn *.filter autodefs.*

--- a/contrib/leew/Makefile
+++ b/contrib/leew/Makefile
@@ -3,4 +3,4 @@ all:
 install:
 source:
 clean:
-	/bin/rm -f nocond *.dvi *.log *.aux *.toc *.tex *.tex nocond.1
+	rm -f nocond *.dvi *.log *.aux *.toc *.tex nocond.1

--- a/contrib/norman/numarkup/Makefile
+++ b/contrib/norman/numarkup/Makefile
@@ -24,7 +24,7 @@ install:
 source: main.c pass1.c latex.c input.c scraps.c names.c arena.c global.c
 
 clean:
-	rm -f *.o *.c *.h *.tex *.log *.dvi *~ *.blg $(TARGET) *.html *~
+	rm -f *.o *.c *.h *.tex *.log *.dvi *~ *.blg $(TARGET) *.html
 
 $(OBJS): global.h
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -109,7 +109,7 @@ uninstall-code: uninstall-shell
 	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
 	(cd lib && $(MAKE) LIB=$(LIB) uninstall)
 install-man:
-	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
+	mkdir -p $(MANDIR) $(MAN7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.1 > $(MANDIR)/cpif.$(MANEXT)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nodefs.1 > $(MANDIR)/nodefs.$(MANEXT)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/noroots.1 > $(MANDIR)/noroots.$(MANEXT)
@@ -143,7 +143,7 @@ uninstall-man:
 	rm -f $(MANDIR)/nountangle.$(MANEXT)
 	rmdir $(MANDIR) $(MAN7DIR) $(MAN) 2>/dev/null || true
 install-gzipped-man:
-	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
+	mkdir -p $(MANDIR) $(MAN7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.1  | gzip -9 > $(MANDIR)/cpif.$(MANEXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nodefs.1  | gzip -9 > $(MANDIR)/nodefs.$(MANEXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/noroots.1  | gzip -9 > $(MANDIR)/noroots.$(MANEXT).gz
@@ -162,7 +162,7 @@ install-gzipped-man:
 	(cd $(MANDIR) && ln notangle.$(MANEXT).gz nountangle.$(MANEXT).gz)
 install-preformat-man:
 	-echo "Warning: install-preformat-man is obsolete, even on Slackware systems" 1>&2
-	mkdir -p $(MAN) $(CATDIR) $(CAT7DIR)
+	mkdir -p $(CATDIR) $(CAT7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.txt  | gzip > $(CATDIR)/cpif.$(MANEXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/nodefs.txt  | gzip > $(CATDIR)/nodefs.$(MANEXT).gz
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/noroots.txt  | gzip > $(CATDIR)/noroots.$(MANEXT).gz

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,12 +50,12 @@ FAQ: FAQ.html
 
 FAQ.html: $(HOME)/www/noweb/FAQ.html
 	rm -f $@
-	/bin/cp $(HOME)/www/noweb/FAQ.html $@
+	cp $(HOME)/www/noweb/FAQ.html $@
 	chmod -w $@
 
 install: install-code install-man install-tex install-elisp
 uninstall: uninstall-code uninstall-man uninstall-tex uninstall-elisp
-	-rmdir $(BIN) $(LIB) 2>/dev/null || true
+	rmdir $(BIN) $(LIB) 2>/dev/null || true
 
 install-shell:
 	mkdir -p $(BIN) $(LIB)
@@ -141,7 +141,7 @@ uninstall-man:
 	rm -f $(MAN7DIR)/nowebfilters.$(MAN7EXT)
 	rm -f $(MANDIR)/noweave.$(MANEXT)
 	rm -f $(MANDIR)/nountangle.$(MANEXT)
-	-rmdir $(MANDIR) $(MAN7DIR) $(MAN) 2>/dev/null || true
+	rmdir $(MANDIR) $(MAN7DIR) $(MAN) 2>/dev/null || true
 install-gzipped-man:
 	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
 	sed -e "s@|LIBDIR|@$(LIBNAME)@" -e "s@|TEXINPUTS|@$(TEXNAME)@" xdoc/cpif.1  | gzip -9 > $(MANDIR)/cpif.$(MANEXT).gz
@@ -185,14 +185,14 @@ install-tex:
 	-texhash || echo "Program texhash not found or failed"
 
 uninstall-tex:
-	rm -f $(TEXINPUTS)/nwmac.tex $(TEXINPUTS)/noweb.sty || true
+	rm -f $(TEXINPUTS)/nwmac.tex $(TEXINPUTS)/noweb.sty
 
 install-elisp:
 	if [ "/dev/null" != "$(ELISP)" ]; then mkdir -p $(ELISP); fi
 	cp elisp/noweb-mode.el $(ELISP)
 
 uninstall-elisp:
-	rm -f $(ELISP)/noweb-mode.el || true
+	rm -f $(ELISP)/noweb-mode.el
 checkin:
 	for i in lib tex xdoc; do (cd $$i && $(MAKE) "CINAME=$(CINAME)" "CIMSG=$(CIMSG)" $@); done
 	for i in c icon awk; do (cd $$i && ci -l $(CINAME) $(CIMSG) *.nw Makefile); done

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -55,12 +55,12 @@ FAQ: FAQ.html
 
 FAQ.html: $(HOME)/www/noweb/FAQ.html
 	rm -f $@
-	/bin/cp $(HOME)/www/noweb/FAQ.html $@
+	cp $(HOME)/www/noweb/FAQ.html $@
 	chmod -w $@
 
 install: install-code install-man install-tex install-elisp
 uninstall: uninstall-code uninstall-man uninstall-tex uninstall-elisp
-	-rmdir $(BIN) $(LIB) 2>/dev/null || true
+	rmdir $(BIN) $(LIB) 2>/dev/null || true
 
 install-shell:
 	mkdir -p $(BIN) $(LIB)
@@ -110,7 +110,7 @@ install-man:
 	<<ordinary pages>>
 uninstall-man:
 	<<uninstall ordinary pages>>
-	-rmdir $(MANDIR) $(MAN7DIR) $(MAN) 2>/dev/null || true
+	rmdir $(MANDIR) $(MAN7DIR) $(MAN) 2>/dev/null || true
 @
 Slackware no longer uses preformatted compressed pages, just
 compressed pages.
@@ -190,14 +190,14 @@ install-tex:
 	-texhash || echo "Program texhash not found or failed"
 
 uninstall-tex:
-	rm -f $(TEXINPUTS)/nwmac.tex $(TEXINPUTS)/noweb.sty || true
+	rm -f $(TEXINPUTS)/nwmac.tex $(TEXINPUTS)/noweb.sty
 
 install-elisp:
 	if [ "/dev/null" != "$(ELISP)" ]; then mkdir -p $(ELISP); fi
 	cp elisp/noweb-mode.el $(ELISP)
 
 uninstall-elisp:
-	rm -f $(ELISP)/noweb-mode.el || true
+	rm -f $(ELISP)/noweb-mode.el
 @
 <<*>>=
 checkin:

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -106,7 +106,7 @@ do
 done
 <<*>>=
 install-man:
-	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
+	mkdir -p $(MANDIR) $(MAN7DIR)
 	<<ordinary pages>>
 uninstall-man:
 	<<uninstall ordinary pages>>
@@ -116,12 +116,12 @@ Slackware no longer uses preformatted compressed pages, just
 compressed pages.
 <<*>>=
 install-gzipped-man:
-	mkdir -p $(MAN) $(MANDIR) $(MAN7DIR)
+	mkdir -p $(MANDIR) $(MAN7DIR)
 	<<compressed pages>>
 <<*>>=
 install-preformat-man:
 	-echo "Warning: install-preformat-man is obsolete, even on Slackware systems" 1>&2
-	mkdir -p $(MAN) $(CATDIR) $(CAT7DIR)
+	mkdir -p $(CATDIR) $(CAT7DIR)
 	<<preformatted compressed pages>>
 <<generate chunks>>=
 NORMALPAGES="cpif nodefs noroots noweb noindex nuweb2noweb notangle noroff sl2h htmltoc"

--- a/src/icon/Makefile
+++ b/src/icon/Makefile
@@ -45,13 +45,13 @@ uninstall:
 	rm -f $(LIB)/autodefs.c
 
 clean:
-	/bin/rm -f *.tex *.dvi *.aux *.log *.blg *.bbl *~ *.toc *.html *.u1 *.u2
-	/bin/rm -f *.[ch] *.ps *.gz
-	/bin/rm -f $(EXECS)
-	/bin/rm -f sl2h
+	rm -f *.tex *.dvi *.aux *.log *.blg *.bbl *~ *.toc *.html *.u1 *.u2
+	rm -f *.[ch] *.ps *.gz
+	rm -f $(EXECS)
+	rm -f sl2h
 
 clobber: clean
-	/bin/rm -f *.icn
+	rm -f *.icn
 
 texdefs.icn: texdefs.nw defns.nw
 	notangle -L'#line %-1L "%F"%N' texdefs.nw defns.nw $(CPIF) $@

--- a/src/tex/Makefile
+++ b/src/tex/Makefile
@@ -23,6 +23,6 @@ support.tex: support.nw
 	noweave -delay -x support.nw > $@
 
 clean:
-	/bin/rm -f *~ *.dvi *.aux *.log *.blg *.bbl *.toc
-	/bin/rm -f support.tex
+	rm -f *~ *.dvi *.aux *.log *.blg *.bbl *.toc
+	rm -f support.tex
 clobber: clean

--- a/src/xdoc/Makefile
+++ b/src/xdoc/Makefile
@@ -109,6 +109,6 @@ guide.html: guide.dvi
 	sl2h guide.tex | htmltoc > $@
 
 clean:
-	/bin/rm -f *.dvi *.log *.blg *~ wc.tex *.ps *.gz *.uu *.html
+	rm -f *.dvi *.log *.blg *~ wc.tex *.ps *.gz *.uu *.html
 clobber: clean
 	rm -f *.1 *.7 *.txt


### PR DESCRIPTION
- Remove a couple duplicate patterns in `rm` rules.
- Remove the absolute path on some `/bin/rm` and `/bin/cp` commands.
- Always use `rm -f` instead of `rm || true` or `-rm` (where the leading dash is Make syntax to ignore errors).
- `rmdir` commands were using two error suppression methods (`-rmdir || true`), prefer `rmdir || true` since it is less noisy than `-rmdir`.
- `mkdir -p` commands do not need parent directories supplied as arguments; add the `-p` flag if missing.