### PR TITLE
Apply compile flags consistently

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,14 +1,13 @@
 SHELL=/bin/sh
 LIB=/dev/null  # to be overridden
-ICONC=icont    # to be overridden
 DIRS=davelove jonkrom leew norman
 
 # don't do kostas; it requires gnu make (ugh)
 
 all:
-	for i in $(DIRS); do (cd $$i && $(MAKE) ICONC=$(ICONC) $@); done
+	for i in $(DIRS); do (cd $$i && $(MAKE) $@); done
 install:
-	for i in $(DIRS); do (cd $$i && $(MAKE) LIB=$(LIB) BIN=$(BIN) $@); done
+	for i in $(DIRS); do (cd $$i && $(MAKE) LIB=$(LIB) $@); done
 source:
 	for i in $(DIRS); do (cd $$i && $(MAKE) $@); done
 clean:

--- a/contrib/norman/Makefile
+++ b/contrib/norman/Makefile
@@ -2,9 +2,9 @@ LIB=/dev/null  # to be overridden
 DIRS=numarkup
 
 all:
-	for i in $(DIRS); do (cd $$i && $(MAKE) ICONC=$(ICONC) ICONT=$(ICONT) $@); done
+	for i in $(DIRS); do (cd $$i && $(MAKE) $@); done
 install:
-	for i in $(DIRS); do (cd $$i && $(MAKE) LIB=$(LIB) BIN=$(BIN) $@); done
+	for i in $(DIRS); do (cd $$i && $(MAKE) LIB=$(LIB) $@); done
 source:
 	for i in $(DIRS); do (cd $$i && $(MAKE) $@); done
 clean:

--- a/contrib/norman/numarkup/Makefile
+++ b/contrib/norman/numarkup/Makefile
@@ -29,7 +29,7 @@ clean:
 $(OBJS): global.h
 
 $(TARGET): $(OBJS)
-	$(CC) -o $@ $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS)
 
 numarkup.html: numarkup.nw
 	noweave -filter l2h -html -index numarkup.nw > $@

--- a/src/INSTALL
+++ b/src/INSTALL
@@ -26,25 +26,35 @@ either Icon or Awk, but Icon is better:
 
 To build noweb:
 
-  1) First point to compilers to be used to built the tools and
+  1) First point to compilers to be used to build the tools and
      library by setting these variables in the Makefile:
        CC         the name of an ANSI C compiler
-       LIBSRC	  'awk' or 'icon', depending on which library you want
+       CFLAGS     flags for your C compiler
+       LIBSRC     'awk' or 'icon', depending on which library you want
+       ICONC      your Icon compiler and flags, for when LIBSRC=icon
+       ICONT      your Icon translator and flags, for when LIBSRC=icon
 
      Now choose locations for the noweb files, and set the appropriate
      variables in the Makefile:
        BIN        on $PATH, will hold notangle, noweave, noroots, ...
        LIB        a directory to store markup, nt, noxref, ...
-       MAN        man pages will go in $MAN/man1
+       MAN        man pages will go in $MAN/man1 and $MAN/man7
        TEXINPUTS  a directory TeX will look for nwmac.tex and noweb.sty
        ELISP      a directory for noweb-mode.el, for emacs 19 and up
-     All of these files are *output* files, where noweb will place
+     All of these are *output* directories, where noweb will place
      binaries and man pages that are customized for your installation.
      Therefore you should:
        - make sure you have permission to write to these directories
        - refrain from making them point into the noweb source distribution
        - arrange for BIN to be on your $PATH and MAN to be on your $MANPATH
      If you don't use emacs, just leave ELISP set to /dev/null.
+
+     Instead of editing the Makefile, you can create a shell script that
+     invokes make with the proper variables.  `nwmake' is an example of
+     such a script; I use it to install noweb at Princeton using the Icon
+     cross-referencer and our local C compiler.  If you make your own
+     script, call it something else so it won't get overwritten by the
+     default nwmake when you unbundle a new distribution.
 
   2) If your modern awk is called something other than `nawk', run the
      `awkname' script to change all references to nawk.  For example,
@@ -72,7 +82,7 @@ To build noweb:
      `contrib' hierarchy.  Get it, set the LIB variable in the
      Makefile, and type 'make all install'.  If you just want the
      nuweb parser, try
-	 (cd ../contrib/norman; make LIB=$LIB all install)
+         (cd ../contrib/norman && make LIB=$LIB all install)
      where $LIB is the noweb LIB directory.
 
   6) On some installations, (e.g., Unix teTeX), you may have to run
@@ -81,12 +91,5 @@ To build noweb:
   7) You can clean up by typing `make clean'.  If you wish, you can
      remove the pre-built sources by typing `make clobber', but then
      you will be unable to build noweb unless you already have noweb.
-
-Instead of editing the Makefile, you can create a shell script that
-invokes make with the proper variables.  `nwmake' is an example of
-such a script; I use it to install noweb at Princeton using the Icon
-cross-referencer and our local C compiler.  If you make your own
-script, call it something else so it won't get overwritten by the
-default nwmake when you unbundle a new distribution.
 
 If you encounter a problem building noweb, try the FAQ file.

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 CC=gcc
 CFLAGS=-ansi -pedantic -O -Wall -Werror
 # If you have Icon, you should use the Icon versions of the noweb pipeline.
-# Set LIBSRC=icon
+#LIBSRC=icon
 LIBSRC=awk
 # If you are lucky enough to have an Icon compiler icont, use ICONC=iconc
 ICONC=icont
@@ -102,12 +102,12 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd $(LIBSRC) && $(MAKE) "ICONT=$(ICONT)" "ICONC=$(ICONC)" LIB=$(LIB) BIN=$(BIN) install)
 	(cd lib && $(MAKE) LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd $(LIBSRC) && $(MAKE) "ICONT=$(ICONT)" "ICONC=$(ICONC)" LIB=$(LIB) BIN=$(BIN) uninstall)
 	(cd lib && $(MAKE) LIB=$(LIB) uninstall)
 install-man:
 	mkdir -p $(MANDIR) $(MAN7DIR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,8 @@
 # See file COPYRIGHT for more information.
 #
 # Adjust these two lines for your ANSI C compiler
-CC=gcc -ansi -pedantic -O -Wall -Werror
-CFLAGS=
+CC=gcc
+CFLAGS=-ansi -pedantic -O -Wall -Werror
 # If you have Icon, you should use the Icon versions of the noweb pipeline.
 # Set LIBSRC=icon
 LIBSRC=awk

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -7,8 +7,8 @@ This nonsense is the result.  (Too bad mk isn't everywhere.)
 # See file COPYRIGHT for more information.
 #
 # Adjust these two lines for your ANSI C compiler
-CC=gcc -ansi -pedantic -O -Wall -Werror
-CFLAGS=
+CC=gcc
+CFLAGS=-ansi -pedantic -O -Wall -Werror
 # If you have Icon, you should use the Icon versions of the noweb pipeline.
 # Set LIBSRC=icon
 LIBSRC=awk

--- a/src/Makefile.nw
+++ b/src/Makefile.nw
@@ -10,7 +10,7 @@ This nonsense is the result.  (Too bad mk isn't everywhere.)
 CC=gcc
 CFLAGS=-ansi -pedantic -O -Wall -Werror
 # If you have Icon, you should use the Icon versions of the noweb pipeline.
-# Set LIBSRC=icon
+#LIBSRC=icon
 LIBSRC=awk
 # If you are lucky enough to have an Icon compiler icont, use ICONC=iconc
 ICONC=icont
@@ -76,12 +76,12 @@ install-code: install-shell
 	mkdir -p $(BIN) $(LIB)
 	strip c/nt c/markup c/mnt c/finduses c/nwmktemp
 	cp c/nt c/markup c/mnt c/finduses c/nwmktemp $(LIB)
-	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) install)
+	(cd $(LIBSRC) && $(MAKE) "ICONT=$(ICONT)" "ICONC=$(ICONC)" LIB=$(LIB) BIN=$(BIN) install)
 	(cd lib && $(MAKE) LIB=$(LIB) install)
 
 uninstall-code: uninstall-shell
 	rm -f $(LIB)/nt $(LIB)/markup $(LIB)/mnt $(LIB)/finduses
-	(cd $(LIBSRC) && $(MAKE) ICONT=$(ICONT) ICONC=$(ICONC) LIB=$(LIB) BIN=$(BIN) uninstall)
+	(cd $(LIBSRC) && $(MAKE) "ICONT=$(ICONT)" "ICONC=$(ICONC)" LIB=$(LIB) BIN=$(BIN) uninstall)
 	(cd lib && $(MAKE) LIB=$(LIB) uninstall)
 @ I do the [[<<shell binaries>>]] before [[$(LIBSRC)]] so that the
 Icon version of [[htmltoc]], if present, will overwrite the Perl

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -2,8 +2,8 @@
 # See file COPYRIGHT for more information.
 #
 # Adjust these two lines for your ANSI C compiler
-CC=gcc -ansi -pedantic -O -Wall -Werror
-CFLAGS=
+CC=gcc
+CFLAGS=-ansi -pedantic -O -Wall -Werror
 
 # after installation, make doc.dvi for literate version
 
@@ -41,19 +41,19 @@ CPIF=>
 all: nt markup mnt finduses nwmktemp
 
 nt: $(TANGLEOBJS)
-	$(CC) $(CFLAGS) -o $@ $(TANGLEOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(TANGLEOBJS)
 
 nwmktemp: nwmktemp.o
-	$(CC) $(CFLAGS) -o $@ nwmktemp.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ nwmktemp.o
 
 finduses: $(FINDUSESOBJS)
-	$(CC) $(CFLAGS) -o $@ $(FINDUSESOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FINDUSESOBJS)
 
 markup: $(MARKUPOBJS)
-	$(CC) $(CFLAGS) -o $@ $(MARKUPOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(MARKUPOBJS)
 
 mnt: $(MNTOBJS)
-	$(CC) $(CFLAGS) -o $@ $(MNTOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(MNTOBJS)
 
 source: $(SRCS)
 touch: $(SRCS)
@@ -90,7 +90,7 @@ FPOBJS=fakepretty.o pretty.o errors.o getline.o match.o strsave.o columns.o gitv
 fakepretty.o: pretty.h
 
 fakepretty: $(FPOBJS)
-	$(CC) $(CFLAGS) -o $@ $(FPOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FPOBJS)
 
 
 gitversion.c: ../gitversion ../../.git/refs/heads/master

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -1,31 +1,35 @@
 # Copyright 1991 by Norman Ramsey.  All rights reserved.
 # See file COPYRIGHT for more information.
-#
+SHELL=/bin/sh
+
 # Adjust these two lines for your ANSI C compiler
 CC=gcc
 CFLAGS=-ansi -pedantic -O -Wall -Werror
 
 # after installation, make doc.dvi for literate version
 
-FINDUSESOBJS=columns.o errors.o finduses.o match.o getline.o recognize.o gitversion.o
-MNTOBJS=mnt.o getline.o match.o modules.o modtrees.o notangle.o \
-	strsave.o errors.o columns.o gitversion.o
 TANGLEOBJS=notangle.o getline.o match.o modules.o modtrees.o strsave.o \
 	main.o errors.o columns.o gitversion.o
 MARKUPOBJS=markmain.o strsave.o markup.o errors.o getline.o columns.o gitversion.o
+MNTOBJS=mnt.o getline.o match.o modules.o modtrees.o notangle.o \
+	strsave.o errors.o columns.o gitversion.o
+FINDUSESOBJS=columns.o errors.o finduses.o match.o getline.o recognize.o gitversion.o
+NWMKTEMPOBJS=nwmktemp.o gitversion.o
+FPOBJS=fakepretty.o pretty.o errors.o getline.o match.o strsave.o columns.o gitversion.o
+
 FILES=markmain.nw markup.nw \
 	main.nw notangle.nw match.nw mnt.nw modules.nw modtrees.nw \
 	finduses.nw recognize.nw \
-	getline.nw columns.nw errors.nw strsave.nw gitversion.o
+	getline.nw columns.nw errors.nw strsave.nw
 
 SRCS=columns.h errors.h getline.h markup.h match.h modtrees.h \
 	modules.h notangle.h recognize.h strsave.h \
-	columns.c errors.c getline.c finduses.c main.c markmain.c markup.c match.c \
-	mnt.c modtrees.c modules.c notangle.c nwmktemp.c recognize.c \
-	strsave.c markup.ps gitversion.o
+	columns.c errors.c getline.c markup.c match.c modtrees.c \
+	modules.c notangle.c recognize.c strsave.c \
+	main.c markmain.c mnt.c finduses.c nwmktemp.c \
+	markup.ps
 
 NOTANGLE=notangle
-SHELL=/bin/sh
 # set this for CPIF and then distribute tools with bad timestamps...
 #CPIF=| cpif
 CPIF=>
@@ -43,17 +47,20 @@ all: nt markup mnt finduses nwmktemp
 nt: $(TANGLEOBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(TANGLEOBJS)
 
-nwmktemp: nwmktemp.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ nwmktemp.o
-
-finduses: $(FINDUSESOBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FINDUSESOBJS)
-
 markup: $(MARKUPOBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(MARKUPOBJS)
 
 mnt: $(MNTOBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(MNTOBJS)
+
+finduses: $(FINDUSESOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FINDUSESOBJS)
+
+nwmktemp: $(NWMKTEMPOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(NWMKTEMPOBJS)
+
+fakepretty: $(FPOBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FPOBJS)
 
 source: $(SRCS)
 touch: $(SRCS)
@@ -63,12 +70,12 @@ boot:
 	touch $(SRCS)
 
 clean:
-	rm -f nt markup mnt finduses fakepretty
+	rm -f nt markup mnt finduses nwmktemp fakepretty
 	rm -f core *.makelog *.tex *.log *.blg *.dvi *.o *.toc *~
 	rm -f *.atac *.trace *.html
 
 clobber: clean
-	rm -f $(SRCS) fakepretty.c pretty.[ch]
+	rm -f $(SRCS) fakepretty.c pretty.[ch] gitversion.c
 
 doc.tex: doc.nw
 	cp doc.nw $@
@@ -85,20 +92,13 @@ doc.ps: doc.dvi
 markup.ps: markmain.nw
 	notangle -Rmarkup.dot markmain.nw | dot -Tps > $@
 
-FPOBJS=fakepretty.o pretty.o errors.o getline.o match.o strsave.o columns.o gitversion.o
-
-fakepretty.o: pretty.h
-
-fakepretty: $(FPOBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(FPOBJS)
-
-
 gitversion.c: ../gitversion ../../.git/refs/heads/master
 	echo 'const char gitversion[] = "'"$$(../gitversion -prefix)"'";' > $@
 
 
 columns.o:      columns.h
 errors.o:       errors.h
+fakepretty.o:   pretty.h
 finduses.o:     errors.h match.h getline.h recognize.h
 getline.o:      columns.h errors.h getline.h
 main.o:         notangle.h errors.h columns.h modules.h modtrees.h

--- a/src/c/pretty.nw
+++ b/src/c/pretty.nw
@@ -225,7 +225,7 @@ static PrettyPrinter make_pp(void *cl, char *name) {
 @ 
 The program is always a filter, so it uses stdin and stdout.
 <<one-pass definitions>>=
-main (int argc, char *argv[]) {
+int main (int argc, char *argv[]) {
   struct io io;
   io.out = stdout;
   io.putline = put_stripped;

--- a/src/limake
+++ b/src/limake
@@ -1,3 +1,3 @@
 #!/bin/sh
 if [ $# -eq 0 ]; then set all install; fi  # "$@" breaks make for empty args
-/usr/bin/make CC="gcc -ansi -pedantic -O -Wall -Werror" LIBSRC=icon BIN=/usr/local/noweb/bin LIB=/usr/local/noweb/lib MAN=/usr/local/noweb/man TEXINPUTS=/usr/share/texmf/tex/plain/misc ELISP=$HOME/emacs "$@"
+/usr/bin/make CC=gcc CFLAGS="-ansi -pedantic -O -Wall -Werror" LIBSRC=icon BIN=/usr/local/noweb/bin LIB=/usr/local/noweb/lib MAN=/usr/local/noweb/man TEXINPUTS=/usr/share/texmf/tex/plain/misc ELISP=$HOME/emacs "$@"

--- a/src/nwmake
+++ b/src/nwmake
@@ -1,3 +1,3 @@
 #!/bin/sh
 if [ $# -eq 0 ]; then set iconlib all install; fi  # "$@" breaks make for empty args
-/bin/make CC="lcc -A -A" BIN=/usr/local/bin LIB=/usr/local/lib/noweb MAN=/usr/local/man TEXINPUTS=/usr/local/lib/tex/inputs "$@"
+/bin/make CC=lcc CFLAGS="-A -A" BIN=/usr/local/bin LIB=/usr/local/lib/noweb MAN=/usr/local/man TEXINPUTS=/usr/local/lib/tex/inputs "$@"

--- a/src/rhmake
+++ b/src/rhmake
@@ -1,3 +1,3 @@
 #!/bin/sh
 if [ $# -eq 0 ]; then set all install; fi  # "$@" breaks make for empty args
-/usr/bin/make CC="lcc -A" LIBSRC=icon BIN=/usr/local/noweb/bin LIB=/usr/local/noweb/lib MAN=/usr/local/noweb/man TEXINPUTS=/usr/share/texmf/tex/latex/local ELISP=$HOME/emacs "$@"
+/usr/bin/make CC=lcc CFLAGS="-A" LIBSRC=icon BIN=/usr/local/noweb/bin LIB=/usr/local/noweb/lib MAN=/usr/local/noweb/man TEXINPUTS=/usr/share/texmf/tex/latex/local ELISP=$HOME/emacs "$@"


### PR DESCRIPTION
Another piece of #10:
* Update compile flags:  Add `$(LDFLAGS)` when linking, add a missing `$(CFLAGS)` to contrib/norman/numarkup, move flags from `$(CC)` to `$(CFLAGS)`.
* Having -Werror in the default `$(CFLAGS)` causes the fakepretty build to fail.  Fix up those warnings/errors, and sort a few parts of the Makefile so that fakepretty (and nwmktemp) is on par with the other targets in src/c.