### PR TITLE
Using koma too

### DIFF
--- a/src/tex/noweb.sty
+++ b/src/tex/noweb.sty
@@ -13,7 +13,8 @@
 \def\nwtagstyle{\footnotesize\Rm}
 \def\nwgitversion{|GITVERSION|}
 % make \hsize in code sufficient for 88 columns
-\setbox0=\hbox{\tt m}
+% Change \tt to \ttfamily
+\setbox0=\hbox{\ttfamily m}
 \newdimen\codehsize
 \codehsize=91\wd0 % 88 columns wasn't enough; I don't know why
 \newdimen\codemargin
@@ -90,15 +91,19 @@ I'll try to avoid such incompatible changes in the future.}%
 \def\nowebindex{\message{<Warning: You need noweave -index to use \string\nowebindex>}}
 % here is support for the new-style (capitalized) font-changing commands
 % thanks to Dave Love
+% Replaced \tt with \ttfamily
+% Replaced \rm with \rmfamily
+% Replaced \it with \itshape
+% Replaced \bf with \bfseries
 \ifx\documentstyle\undefined
-  \let\Rm=\rm \let\It=\it \let\Tt=\tt       % plain
+  \let\Rm=\rmfamily \let\It=\itshape \let\Tt=\ttfamily  % plain
 \else\ifx\selectfont\undefined
-  \let\Rm=\rm \let\It=\it \let\Tt=\tt       % LaTeX OFSS
+  \let\Rm=\rmfamily \let\It=\itshape \let\Tt=\ttfamily  % LaTeX OFSS
 \else                                       % LaTeX NFSS
-  \def\Rm{\reset@font\rm}
-  \def\It{\reset@font\it}
-  \def\Tt{\reset@font\tt}
-  \def\Bf{\reset@font\bf}
+  \def\Rm{\reset@font\rmfamily}
+  \def\It{\reset@font\itshape}
+  \def\Tt{\reset@font\ttfamily}
+  \def\Bf{\reset@font\bfseries}
 \fi\fi
 \ifx\reset@font\undefined \let\reset@font=\relax \fi
 \def\nwbackslash{\char92}
@@ -349,11 +354,11 @@ I'll try to avoid such incompatible changes in the future.}%
 \newcount\@nwpagecount
 \def\@nwfirstpagel#1{% label
   \@ifundefined{r@#1}{\@warning{Reference `#1' on page \thepage \space undefined}%
-                      \nwix@cons\nw@pages{\\{\bf ??}}}{%
+                      \nwix@cons\nw@pages{\\{\bfseries ??}}}{%
     \edef\@tempa{\noexpand\@nwfirstpage\subpagepair{#1}{#1}}\@tempa}}
 \def\@nwnextpagel#1{% label
   \@ifundefined{r@#1}{\@warning{Reference `#1' on page \thepage \space undefined}%
-                      \nwix@cons\nw@pages{\\{\bf ??}}}{%
+                      \nwix@cons\nw@pages{\\{\bfseries ??}}}{%
     \edef\@tempa{\noexpand\@nwnextpage\subpagepair{#1}{#1}}\@tempa}}
 \def\@pagesl#1{%  list of labels
   \gdef\nw@pages{}\@nwpagecount=0

--- a/src/tex/support.nw
+++ b/src/tex/support.nw
@@ -36,7 +36,8 @@ which code is set, and [[\codemargin]], which is the amount by which
 it is indented.\stylehook
 <<kernel>>=
 % make \hsize in code sufficient for 88 columns
-\setbox0=\hbox{\tt m}
+% Change \tt to \ttfamily
+\setbox0=\hbox{\ttfamily m}
 \newdimen\codehsize
 \codehsize=91\wd0 % 88 columns wasn't enough; I don't know why
 \newdimen\codemargin
@@ -218,15 +219,19 @@ extra [[\reset@font]] does no harm.]
 <<kernel>>=
 % here is support for the new-style (capitalized) font-changing commands
 % thanks to Dave Love
+% Replaced \tt with \ttfamily
+% Replaced \rm with \rmfamily
+% Replaced \it with \itshape
+% Replaced \bf with \bfseries
 \ifx\documentstyle\undefined
-  \let\Rm=\rm \let\It=\it \let\Tt=\tt       % plain
+  \let\Rm=\rmfamily \let\It=\itshape \let\Tt=\ttfamily  % plain
 \else\ifx\selectfont\undefined
-  \let\Rm=\rm \let\It=\it \let\Tt=\tt       % LaTeX OFSS
+  \let\Rm=\rmfamily \let\It=\itshape \let\Tt=\ttfamily  % LaTeX OFSS
 \else                                       % LaTeX NFSS
-  \def\Rm{\reset@font\rm}
-  \def\It{\reset@font\it}
-  \def\Tt{\reset@font\tt}
-  \def\Bf{\reset@font\bf}
+  \def\Rm{\reset@font\rmfamily}
+  \def\It{\reset@font\itshape}
+  \def\Tt{\reset@font\ttfamily}
+  \def\Bf{\reset@font\bfseries}
 \fi\fi
 \ifx\reset@font\undefined \let\reset@font=\relax \fi
 @ 
@@ -967,10 +972,10 @@ We no longer use Rainer's new expandable definitions of [[\ref]] and
 elapsed that this should no longer be necessary.
 <<old noweb.sty>>=
 % RmS 92/08/14: made \ref and \pageref robust
-\def\ref#1{\@ifundefined{r@#1}{{\bf ??}<<warn of undefined reference to [[#1]]>>}%
+\def\ref#1{\@ifundefined{r@#1}{{\bfseries ??}<<warn of undefined reference to [[#1]]>>}%
     {\expandafter\expandafter\expandafter
      \@car\csname r@#1\endcsname\@nil\null}}
-\def\pageref#1{\@ifundefined{r@#1}{{\bf ??}<<warn of undefined reference to [[#1]]>>}%
+\def\pageref#1{\@ifundefined{r@#1}{{\bfseries ??}<<warn of undefined reference to [[#1]]>>}%
      {\expandafter\expandafter\expandafter
       \@cdr\csname r@#1\endcsname\@nil\null}}
 \def\@refpair#1{\@ifundefined{r@#1}{{0}{0}<<warn of undefined reference to [[#1]]>>}%


### PR DESCRIPTION
Improved Patch for Issue 26 edited src/tex/noweb.sty and src/tex/support.nw
It is already available in the Debian Repo as revision2 and 3.
You can see the test result under https://salsa.debian.org/ddp-team/dpb/-/tree/master (Source Code) and https://ddp-team.pages.debian.net/dpb/BuildWithGBP.pdf.