### PR TITLE
noweb-select-mode: replace (=  ...) by (equal ...) 

### DIFF
--- a/src/elisp/noweb-mode.el
+++ b/src/elisp/noweb-mode.el
@@ -925,7 +925,7 @@ and and update the chunk vector."
 	(end (noweb-chunk-boundary-forward)))
     (save-restriction
       (narrow-to-region beg end)
-      (if (= (char-after beg) ?<)
+      (if (equal (char-after beg) ?<)
 	  ;; Inside a code chunk
 	  (if (equal major-mode noweb-code-mode)
 	      nil


### PR DESCRIPTION
In noweb-select-mode: replace `(=  ...)` by `(equal ...)`  because `(char-after ...)` can return `'nil`.
This appears to `fix` the loading problems I had with recent emacs versions.